### PR TITLE
fix: DbContextTransactionFilter needs explicit check on exception inner action

### DIFF
--- a/ContosoUniversity/Infrastructure/DbContextTransactionFilter.cs
+++ b/ContosoUniversity/Infrastructure/DbContextTransactionFilter.cs
@@ -20,9 +20,17 @@ namespace ContosoUniversity.Infrastructure
             {
                 await _dbContext.BeginTransactionAsync();
 
-                await next();
+                var actionExecuted = await next();
+                if (actionExecuted.Exception != null && !actionExecuted.ExceptionHandled)
+                {
+                    _dbContext.RollbackTransaction();
 
-                await _dbContext.CommitTransactionAsync();
+                }
+                else
+                {
+                    await _dbContext.CommitTransactionAsync();
+
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
Small (but important) update on the DbContextTransactionFilter.
In the current implementation no transaction rollback at all will happen when somewhere in the code an exception is thrown.
It took me a while to figure out why, but the await next() block needs to be examined more in detail on potential exceptions of the inner action. Just surrounding with a try catch is apparently insufficient :)
Cheers
paul.